### PR TITLE
Base URL validation rework #177

### DIFF
--- a/grails-app/services/streama/SettingsService.groovy
+++ b/grails-app/services/streama/SettingsService.groovy
@@ -59,11 +59,11 @@ class SettingsService {
     try {
         def actualUrl = new java.net.URL(url);
         resultValue.success = true;
-        resultValue.message = "The given url is valid."
+        resultValue.message = "The entered url is valid."
     }
     catch (MalformedURLException ex) {
         resultValue.error = true;
-        resultValue.message = "The url given is invalid."
+        resultValue.message = "The entered url is invalid."
     }
   }
 

--- a/grails-app/services/streama/SettingsService.groovy
+++ b/grails-app/services/streama/SettingsService.groovy
@@ -14,6 +14,9 @@ class SettingsService {
   def validate(Settings settingsInstance) {
     def resultValue = [:]
 
+    if (settingsInstance.settingsKey == 'Base URL') {
+        validateURL(settingsInstance.value, resultValue)
+    }
     if (settingsInstance.settingsKey == 'Upload Directory') {
       validateUploadDirectoryPermissions(settingsInstance.value + '/upload', resultValue)
     }
@@ -52,6 +55,17 @@ class SettingsService {
     }
   }
 
+  def validateURL(String url, resultValue) {
+    try {
+        def actualUrl = new java.net.URL(url);
+        resultValue.success = true;
+        resultValue.message = "The given url is valid."
+    }
+    catch (MalformedURLException ex) {
+        resultValue.error = true;
+        resultValue.message = "The url given is invalid."
+    }
+  }
 
   def validateTheMovieDbAPI(Settings settingsInstance, resultValue) {
     try {
@@ -67,5 +81,3 @@ class SettingsService {
   }
 
 }
-
-

--- a/grails-app/services/streama/SettingsService.groovy
+++ b/grails-app/services/streama/SettingsService.groovy
@@ -58,10 +58,11 @@ class SettingsService {
   def validateURL(String url, resultValue) {
     try {
         def actualUrl = new java.net.URL(url);
+        actualUrl.getContent();
         resultValue.success = true;
         resultValue.message = "The entered url is valid."
     }
-    catch (MalformedURLException ex) {
+    catch (Exception ex) {
         resultValue.error = true;
         resultValue.message = "The entered url is invalid."
     }


### PR DESCRIPTION
Added actual validation, so now there has to be entered a valid URL like http://localhost:8080.
Added URL testing, so now the validation will try to connect to the Base URL to make sure it is valid.
This should solve a bug pointed out in #177